### PR TITLE
Allow URL highlighting to be turned off via a preference. Fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Anything from [this list](https://docs.python.org/2/library/webbrowser.html#webb
         "clickable_urls_browser": "firefox"
     }
 
+## Disabling URL highlighting
+
+Unfortunately, the only way to underline a block of text in ST2 is a hack with underlining empty regions, and there is no way to control its appearance. If you want, you can disable URL highlighting by setting the option highlight_urls to false in Preferences > Package Settings > Clickable URLs > Settings - User
+
+    {
+        "highlight_urls": false
+    }
+
+
 * * *
 
 By [Leonid Shevtsov](http://leonid.shevtsov.me)

--- a/clickable_urls.py
+++ b/clickable_urls.py
@@ -42,6 +42,12 @@ class UrlHighlighter(sublime_plugin.EventListener):
 
         UrlHighlighter.urls_for_view[view.id()] = urls
 
+        highlight_urls = sublime.load_settings('ClickableUrls.sublime-settings').get('highlight_urls', True)
+
+        if (highlight_urls):
+            self.highlight_urls(view)
+
+    def highlight_urls(self, view):
         # We need separate regions for each lexical scope for ST to use a proper color for the underline
         # TODO someday Sublime Text 3 will support drawing underlines. Then this code could be civilised and de-hacked
         scope_map = {}


### PR DESCRIPTION
This PR introduces a setting "highlight_urls" that defaults to True, but can be set to False to disable URL highlighting. 
